### PR TITLE
Added picard-tangoinfo plugin

### DIFF
--- a/plugins/picard-tangoinfo/README.md
+++ b/plugins/picard-tangoinfo/README.md
@@ -1,0 +1,34 @@
+# tango.info plugin for MusicBrainz Picard
+The [old one](http://simbatango.com/2010/07/23/updated-musicbrainz-picard-plugins-for-tango-info/)
+is not working anymore, the opendata initiative has stalled,
+so we are back to good old web scraping.
+
+# Usage
+You will need MusicBrainz Picard and these python libraries:
+
+- urllib2
+- bs4(BeautifulSoup)
+- re(should be preinstalled)
+
+Put `tangoinfo.py` into your plugin directory. On \*nix, this
+would be `~/.config/MusicBrainz/Picard/plugins`, consult the
+Picard documentation for other operating systems.  
+Then open Picard, navigate to `Options -> Options -> Plugins` and enable
+the one called `ix5 - tango.info`, then restart and use Picard
+like you usually would.
+
+If(and **only if**) there is a valid `barcode` tag for your files,
+the plugin will try to look up the corresponding album on *tango.info*
+and fill in the `genre`(capitalized) and `year` tags for you.
+
+# What it does
+It looks up the barcode, constructs the url for the corresponding 
+*tango.info* album('product'/'TINP') page, parses the html,
+looks for the `tracks` table and extracts `genre` and `Perf date`.
+
+# Future
+Provided [Tobias Conradi](https://tango.info/tangoinfo/eng/contact)
+does not change the page structure in a manner that breaks this plugin,
+you might be able to map instrumentalists and vocalists to the id3 tags
+of your liking. Let us hope he does not ban urllib2 clients,
+or we will have to fumble with user agents.

--- a/plugins/picard-tangoinfo/tangoinfo.py
+++ b/plugins/picard-tangoinfo/tangoinfo.py
@@ -1,0 +1,71 @@
+"""
+Get genre, performed date and (soon) vocalists and instrumentalists from tango.info
+Uses web scraping since opendata is disabled for now
+"""
+
+PLUGIN_NAME = 'ix5 tango.info'
+PLUGIN_AUTHOR = 'ix5'
+PLUGIN_DESCRIPTION = 'change <em>genre</em> and <em>year</em> fields'
+PLUGIN_VERSION = '0.1'
+PLUGIN_API_VERSIONS = ["0.9.0", "0.12", "1.0.0"]
+
+from picard import log
+from picard.metadata import register_track_metadata_processor
+import re,os
+
+from bs4 import BeautifulSoup
+import urllib2
+
+scraped_data = {}
+
+def scrape_page(barcode):
+    url = ("https://tango.info/0" + str(barcode))
+    page = urllib2.urlopen(url).read()
+    soup = BeautifulSoup(page, "lxml")
+    table = soup.findAll("table")[3]
+    x = (len(table.findAll('tr')) -1)
+
+
+    for row in table.findAll('tr')[1:]:
+        col = row.findAll('td')
+        genre = col[3].getText().capitalize()
+        perf_date = col[6].getText()
+        # checks
+        info = col[-1].find('a').get('href').split('/')[1] # get TINT
+        #track_tint = "0" + str(int(metadata["barcode"])) + "-" + str(mydiscnumber) + "-" + metadata["tracknumber"]
+        scraped_data[info] = {"genre": genre, "year": perf_date}
+        #: Data expected to be in this format:
+        # ["Side", "Tracknr", "Title", "Genre", "Instrumentalists", "Vocalists", "Perf Date", "Duration", "Info"]
+
+_discnumber_re = re.compile(r"\s+\(disc (\d+)(?::\s+([^)]+))?\)")
+
+def get_discnumber(metadata):
+    retval = 1
+    if (is_integer(metadata["discnumber"])):
+        if metadata["discnumber"]>0:
+            retval = metadata["discnumber"]
+        else:	
+            matches = _discnumber_re.search(metadata["album"])
+            if matches:
+                retval = matches.group(1)
+    return retval
+
+def is_integer(testinteger):
+	try:
+		int(testinteger)
+		return True
+	except:
+		return False	
+
+
+def set_data(tagger, metadata, release, track):
+    mydiscnumber = get_discnumber(metadata)
+    tangoinfo_tint = str("00" + str(int(metadata["barcode"])) + "-" + str(mydiscnumber) + "-" + metadata["tracknumber"])
+    #: prefixing 00 is weird, but should work
+    scrape_page(metadata["barcode"])
+    metadata['genre'] = scraped_data[tangoinfo_tint]['genre']
+    log.debug("Set genre %s" % scraped_data[tangoinfo_tint]['genre'])
+    metadata['year'] = scraped_data[tangoinfo_tint]['year']
+    log.debug("Set year: %s" % scraped_data[tangoinfo_tint]['year'])
+
+register_track_metadata_processor(set_data)


### PR DESCRIPTION
Hey Picard devs,

we tango folks really like MusicBrainz. But sometimes, it does not have enough information on the really old recordings. And in tango music, there is usually little doubt about the genre. And most importantly, we do not really care about the release date of a compilation of old songs, we *have* to know the original release date(30s, 40s, 50s are all very different eras to us).
So that is why tagging tango music involves "cleaning up" with Picard, and then tagging genre, release date and the singers manually by cross-referencing tango.info or other sites.

I have written this plugin to ease that process in Picard. It ain't pretty, as it scrapes the website and only works of MusicBrainz provides a barcode, but I believe it will help many tango DJs organize their collections better and save a lot of time.

Let me know if there is a problem with approving plugins that utilize scraping(tango.info has shut down their opendata initiative, sadly) or if the code could be improved. There seems to be very little information on the plugin API; this is my best shot.
I can confirm the plugin works on Ubuntu 15.10 with Picard version 1.3.2 from the repositories.