### PR TITLE
PICARD-963: addrelease: Always use HTTPS for MusicBrainz

### DIFF
--- a/plugins/addrelease/addrelease.py
+++ b/plugins/addrelease/addrelease.py
@@ -11,6 +11,7 @@ PLUGIN_API_VERSIONS = ["1.0.0"]
 
 from picard import config
 from picard.cluster import Cluster
+from picard.const import MUSICBRAINZ_SERVERS
 from picard.file import File
 from picard.util import webbrowser2
 from picard.ui.itemviews import BaseAction, register_cluster_action, register_file_action
@@ -39,7 +40,7 @@ HTML_ATTR_ESCAPE = {
 def mbserver_url(path):
     host = config.setting["server_host"]
     port = config.setting["server_port"]
-    if port == 443:
+    if host in MUSICBRAINZ_SERVERS or port == 443:
         urlstring = "https://%s%s" % (host, path)
     elif port is None or port == 80:
         urlstring = "http://%s%s" % (host, path)

--- a/plugins/addrelease/addrelease.py
+++ b/plugins/addrelease/addrelease.py
@@ -6,7 +6,7 @@ PLUGIN_DESCRIPTION = "Adds a plugin context menu option to clusters and single\
  files to help you quickly add them as releases or standalone recordings to\
  the MusicBrainz database via the website by pre-populating artists,\
  track names and times."
-PLUGIN_VERSION = "0.7"
+PLUGIN_VERSION = "0.7.1"
 PLUGIN_API_VERSIONS = ["1.0.0"]
 
 from picard import config


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/PICARD-963 / https://github.com/metabrainz/picard-plugins/issues/77

https://tickets.metabrainz.org/browse/MBH-466 broke addrelease.py's functionality for users submitting to musicbrainz.org on port 80 (the default settings!), as HTTP 302 redirects don't work properly for POST requests. This PR makes `addrelease.py` always use HTTPS for MusicBrainz.org servers, which alleviates the issue.