### PR TITLE
PICARD-983, PICARD-984: Fix wikidata plugin genre merges and ui problems

### DIFF
--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright © 2016 Daniel sobey <dns@dns.id.au >
 
 # This work is free. You can redistribute it and/or modify it under the

--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -55,7 +55,13 @@ class wikidata:
         if item_id in self.cache.keys():
             log.info('WIKIDATA: found in cache')
             genre_list=self.cache.get(item_id);
-            metadata["genre"] = genre_list
+            new_genre = metadata.getall("genre")
+
+            for str in genre_list:
+                if str not in new_genre:
+                    new_genre.append(str)
+                    log.debug('WIKIDATA: appending genre %s' % str)
+            metadata["genre"] = new_genre
             
             if tagger._requests==0:
                 tagger._finalize_loading(None)

--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -8,7 +8,7 @@
 PLUGIN_NAME = 'wikidata-genre'
 PLUGIN_AUTHOR = 'Daniel Sobey'
 PLUGIN_DESCRIPTION = 'query wikidata to get genre tags'
-PLUGIN_VERSION = '0.1'
+PLUGIN_VERSION = '0.2'
 PLUGIN_API_VERSIONS = ["0.9.0", "0.10", "0.15"]
 PLUGIN_LICENSE = 'WTFPL'
 PLUGIN_LICENSE_URL = 'http://www.wtfpl.net/'

--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -55,13 +55,9 @@ class wikidata:
         if item_id in self.cache.keys():
             log.info('WIKIDATA: found in cache')
             genre_list=self.cache.get(item_id);
-            new_genre = metadata.getall("genre")
-
-            for genre in genre_list:
-                if genre not in new_genre:
-                    new_genre.append(genre)
-                    log.debug('WIKIDATA: appending genre %s' % genre)
-            metadata["genre"] = new_genre
+            new_genre = set(metadata.getall("genre"))
+            new_genre.update(genre_list)
+            metadata["genre"] = list(new_genre)
             
             if tagger._requests==0:
                 tagger._finalize_loading(None)
@@ -181,12 +177,9 @@ class wikidata:
             
             log.debug('WIKIDATA: total items to update: %s ' % len(self.requests[item_id]))
             for metadata in self.requests[item_id]:
-                new_genre = metadata.getall("genre")
-                for genre in genre_list:
-                    if genre not in new_genre:
-                        new_genre.append(genre)
-                        log.debug('WIKIDATA: appending genre %s' % genre)
-                metadata["genre"] = new_genre
+                new_genre = set(metadata.getall("genre"))
+                new_genre.update(genre_list)
+                metadata["genre"] = list(new_genre)
                 self.cache[item_id]=genre_list
                 log.debug('WIKIDATA: setting genre : %s ' % genre_list)
                 

--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -163,7 +163,7 @@ class wikidata:
                                     list1=node1.children.get('name')
                                     for node2 in list1:
                                         if node2.attribs.get('lang')=='en':
-                                            genre=node2.text
+                                            genre=node2.text.title()
                                             genre_list.append(genre)
                                             log.debug('Our genre is: %s' % genre)
                                             

--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -57,10 +57,10 @@ class wikidata:
             genre_list=self.cache.get(item_id);
             new_genre = metadata.getall("genre")
 
-            for str in genre_list:
-                if str not in new_genre:
-                    new_genre.append(str)
-                    log.debug('WIKIDATA: appending genre %s' % str)
+            for genre in genre_list:
+                if genre not in new_genre:
+                    new_genre.append(genre)
+                    log.debug('WIKIDATA: appending genre %s' % genre)
             metadata["genre"] = new_genre
             
             if tagger._requests==0:
@@ -182,10 +182,10 @@ class wikidata:
             log.debug('WIKIDATA: total items to update: %s ' % len(self.requests[item_id]))
             for metadata in self.requests[item_id]:
                 new_genre = metadata.getall("genre")
-                for str in genre_list:
-                    if str not in new_genre:
-                        new_genre.append(str)
-                        log.debug('WIKIDATA: appending genre %s' % str)
+                for genre in genre_list:
+                    if genre not in new_genre:
+                        new_genre.append(genre)
+                        log.debug('WIKIDATA: appending genre %s' % genre)
                 metadata["genre"] = new_genre
                 self.cache[item_id]=genre_list
                 log.debug('WIKIDATA: setting genre : %s ' % genre_list)

--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -174,8 +174,7 @@ class wikidata:
             
             log.debug('WIKIDATA: total items to update: %s ' % len(self.requests[item_id]))
             for metadata in self.requests[item_id]:
-                new_genre=[]
-                new_genre.append(metadata["genre"])
+                new_genre = metadata.getall("genre")
                 for str in genre_list:
                     if str not in new_genre:
                         new_genre.append(str)

--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -128,6 +128,7 @@ class wikidata:
                 if tagger._requests==0: 
                     tagger._finalize_loading(None)
                 log.debug('WIKIDATA:  TOTAL REMAINING REQUESTS %s' % tagger._requests)
+            del self.requests[item_id]
             self.lock.release()
             
     def process_wikidata(self,wikidata_url,item_id):
@@ -193,6 +194,7 @@ class wikidata:
             if tagger._requests==0:
                 tagger._finalize_loading(None)
             log.info('WIKIDATA:  TOTAL REMAINING REQUESTS %s' % tagger._requests)
+        del self.requests[item_id]
         self.lock.release()
         
     def process_track(self, album, metadata, trackXmlNode, releaseXmlNode):


### PR DESCRIPTION
This fixes the plugin detection of duplicate genres so they're merged correctly
instead of resulting on a genre list like ["Rock; pop", "pop"]
Also fixes the freeze of the message "loading album information" which never finished when an album was refreshed.
It uses title() for wikidata genres so they can be compared with folksonomy tags to find duplicates.
Finally, it also adds a encoding python header since the file contains non-ASCII characters.

https://tickets.metabrainz.org/browse/PICARD-983
https://tickets.metabrainz.org/browse/PICARD-984