### PR TITLE
Add note about licensing to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository hosts plugins for [MusicBrainz Picard](https://picard.musicbrainz.org/). If you're a plugin author and would like to include your plugin here, simply open a pull request.
 
+Note that new plugins being added to the repository should be under the GNU General Public License version 2 ("GPL") or a license compatible with it. See https://www.gnu.org/licenses/license-list.html for a list of compatible licenses.
+
 ## Development Notes
 
 The script `generate.py` will generate a file called `plugins.json`, which contains metadata about all the plugins in this repository. `plugins.json` is used by [picard-website](https://github.com/musicbrainz/picard-website) and Picard itself to display information about downloadable plugins.


### PR DESCRIPTION
Picard itself is licensed under the GPLv2 which means that any plugins written specifically for Picard might be argued to be under GPLv2 themselves due to GPLv2's viral nature, either due to being derived from Picard to some extent, or due to linking to Picard at runtime.

To avoid any legal issues (and to make sure we have the rights to distribute and change plugins for the future) the added sentence declares that new plugins to the repository should be under a GPLv2-compatible license (ie., a license "more free" than GPLv2 is also acceptable).

Also, be declaring it as "new plugins" the statement is "grandfathering" plugins already in the repository. Ideally these plugins should eventually get sorted out (see also https://github.com/metabrainz/picard-plugins/issues/5 ), but this should at least be something we can point new contributors to so we don't make the current license mess worse. :)